### PR TITLE
CSS Reformat

### DIFF
--- a/public/css/draft.css
+++ b/public/css/draft.css
@@ -6,12 +6,12 @@ body {
 .draft-container {
     display: flex;
     justify-content: space-between;
-    margin: 20px;
+    margin: 20px 5px;
 }
 
 .champion-pool-container {
     flex-grow: 1;
-    margin: 0 20px;
+    margin: 0 0px;
     display: flex;
     flex-direction: column;
 }
@@ -39,7 +39,7 @@ body {
 
 .blue-side-header {
     margin-right: 20px;
-    margin-left: 20px;
+    margin-left: 0px;
     margin-top: 0px;
     margin-bottom: 5px;
     height: 40px;
@@ -52,7 +52,7 @@ body {
 }
 
 .red-side-header {
-    margin-right: 20px;
+    margin-right: 0px;
     margin-left: 20px;
     margin-top: 0px;
     margin-bottom: 5px;
@@ -131,31 +131,36 @@ body {
     justify-items: center;
 }
 
-.blue-side,
-.red-side {
-    width: 200px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+.blue-side {
+  width: 245px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start; /*<---------*/
 }
 
+.red-side {
+  width: 245px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end; /*<---------*/
+}
 #blue-bans {
     display: flex;
     justify-content: flex-start;
     margin-top: 3px;
-    margin-left: 35px;
+    margin-left: 0px;
 }
 
 #red-bans {
     display: flex;
     justify-content: flex-end;
     margin-top: 3px;
-    margin-right: 19px;
+    margin-right: -10px;
 }
 
 .pick-slot {
     width: 240px;
-    height: 83px;
+    height: 85px;
     border-radius: 4px;
     position: relative;
     display: inline-block;
@@ -274,4 +279,14 @@ body {
     font-size: 16px;
     background-color: rgb(236, 209, 59);
     border: 0;
+}
+
+#blue-picks {
+    display:flex;
+    flex-direction: column;
+}
+
+#red-picks {
+    display: flex;
+    flex-direction: column;
 }

--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -323,23 +323,23 @@ function updateFearlessBanSlots() { //controls fearless bans
 			break;
 		case 2:
 			fearlessBansPerSide = 5;
-			leftMargin = -90;
-			rightMargin = -96;
+			leftMargin = 0;
+			rightMargin = 0;
 			break;
 		case 3:
 			fearlessBansPerSide = 10;
-			leftMargin = 60;
-			rightMargin = 54;
+			leftMargin = 0;
+			rightMargin = 0;
 			break;
 		case 4:
 			fearlessBansPerSide = 15;
-			leftMargin = 210;
-			rightMargin = 204;
+			leftMargin = 0;
+			rightMargin = 0;
 			break;
 		case 5:
 			fearlessBansPerSide = 20;
-			leftMargin = 360;
-			rightMargin = 354;
+			leftMargin = 0;
+			rightMargin = 0;
 			break;
 		default:
 			fearlessBansPerSide = 0;


### PR DESCRIPTION
Made changes to the CSS code of Fearless draft, mostly making the red and blueside pick/ban columns' flex alignment to be `flex-start` and `flex-end` as opposed to `center`, then fixing up the padding and spacing on all other elements following that change. 

This change should make it so that the *fearless* pick and bans, which accumulate after every draft, will always be justified accordingly, without needing to adjust their padding using javascript every time the fearless bans are updated. 

Thus, fearlessdraft.net should look more or less the same as before, but removing the dynamic padding adjustment on every update of the fearless bans should make it so that operators in OBS/VMix trying to use custom CSS injections will be able to adjust the spacing and size of the fearless bans at ease, without clashing with the javascript code.