### PR TITLE
entirely removing js margins on blue and red fearless containers

### DIFF
--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -315,38 +315,8 @@ function updateFearlessBanSlots() { //controls fearless bans
 	const blueFearlessBansDiv = document.querySelector('#blue-fearless-bans');
 	const redFearlessBansDiv = document.querySelector('#red-fearless-bans');
 
-	switch (matchNumber) {
-		case 1:
-			fearlessBansPerSide = 0;
-			leftMargin = 0;
-			rightMargin = 0;
-			break;
-		case 2:
-			fearlessBansPerSide = 5;
-			leftMargin = 0;
-			rightMargin = 0;
-			break;
-		case 3:
-			fearlessBansPerSide = 10;
-			leftMargin = 0;
-			rightMargin = 0;
-			break;
-		case 4:
-			fearlessBansPerSide = 15;
-			leftMargin = 0;
-			rightMargin = 0;
-			break;
-		case 5:
-			fearlessBansPerSide = 20;
-			leftMargin = 0;
-			rightMargin = 0;
-			break;
-		default:
-			fearlessBansPerSide = 0;
-			leftMargin = 0;
-			rightMargin = 0;
-			break;
-	}
+	fearlessBansPerSide = (matchNumber-1)*5; //should be simpler than using switch and case unless matchNumber can go above 5
+
 	blueFearlessBanSlots.forEach((slot, index) => {
 		slot.style.display = index < fearlessBansPerSide ? 'flex' : 'none';
 	});
@@ -354,8 +324,6 @@ function updateFearlessBanSlots() { //controls fearless bans
 	redFearlessBanSlots.forEach((slot, index) => {
 		slot.style.display = index < fearlessBansPerSide ? 'flex' : 'none';
 	});
-	blueFearlessBansDiv.style.marginLeft = `${leftMargin}px`;
-	redFearlessBansDiv.style.marginRight = `${rightMargin}px`;
 }
 
 function lockChamp() { //lock in champ


### PR DESCRIPTION
Forgot that as long as the JS is setting any value, even if it's 0, it will override the native CSS file, so I removed all the code that has anything to do with setting margins on the div containers for red and blue bans. 

This also removed the need for a case and switch, so I also removed that code and replaced it with `fearlessBansPerSide = (matchNumber-1)*5;` 

