### PR TITLE
Removing margins, fixes visual bug

### DIFF
--- a/public/css/draft.css
+++ b/public/css/draft.css
@@ -224,14 +224,14 @@ body {
     display: flex;
     justify-content: flex-start;
     margin-top: 7px;
-    margin-left: 60px;
+    margin-left: 0px;
 }
 
 #red-fearless-bans {
     display: flex;
     justify-content: flex-end;
     margin-top: 7px;
-    margin-right: 54px;
+    margin-right: -5px;
 }
 
 #blue-fearless-bans::before,

--- a/public/css/draft.css
+++ b/public/css/draft.css
@@ -290,3 +290,16 @@ body {
     display: flex;
     flex-direction: column;
 }
+
+/*
+    Change the color, thickness, etc. of the champion hover outlines, and the header outlines
+*/
+.pick-champ-outline {
+    outline: 2px solid rgb(236, 209, 59); /*default 2px solid rgb(236, 209, 59)*/
+}
+.header-select-outline {
+    outline: 2px solid rgb(236, 209, 59); /* default 2px solid rgb(236, 209, 59)*/
+}
+.header-default-outline {
+    outline: 2px solid black; /*default 2px solid black*/
+}

--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -24,21 +24,6 @@ let selectedChampion = null;
 let viewingPreviousDraft = false;
 let isLocking = false;
 
-//Dynamically fetching the CSS style for the hover and selection borders from draft.css
-//by instantiating a dummy div, assigning it a CSS style, then grabbing the border data as a 
-//string for use in colorBorder()
-const tempElement = document.createElement('div');
-document.body.appendChild(tempElement); // Append temporarily to get computed styles
-function fetchOutlineTempElement(className) { //Returns the CSS outline string from a CSS className in draft.css
-	tempElement.classList.value = ""; //clear all currently attached classes
-	tempElement.classList.add(className);
-	return getComputedStyle(tempElement).outline;
-}
-const headerSelectOutline = fetchOutlineTempElement('header-select-outline');
-const headerDefaultOutline = fetchOutlineTempElement('header-default-outline');
-const pickChampOutline = fetchOutlineTempElement('pick-champ-outline');
-// Remove the temp element after fetching the styles
-document.body.removeChild(tempElement);
 
 
 function startTimer() {
@@ -271,7 +256,24 @@ confirmButton.addEventListener('click', () => { //lock in/ready button
 	}
 });
 
+const tempElement = document.createElement('div');
+document.body.appendChild(tempElement); // Append temporarily to get computed styles
+function fetchOutlineTempElement(className) { //Returns the CSS outline string from a CSS className in draft.css
+	//Dynamically fetching the CSS style for the hover and selection borders from draft.css
+	//by instantiating a dummy div, assigning it a CSS style, then grabbing the border data as a 
+	//string for use in colorBorder()
+	tempElement.classList.value = ""; //clear all currently attached classes
+	tempElement.classList.add(className);
+	return getComputedStyle(tempElement).outline;
+}
+
 function colorBorder() { //shows who is picking currently
+	document.body.appendChild(tempElement);
+	let headerSelectOutline = fetchOutlineTempElement('header-select-outline');
+	let headerDefaultOutline = fetchOutlineTempElement('header-default-outline');
+	let pickChampOutline = fetchOutlineTempElement('pick-champ-outline');
+	document.body.removeChild(tempElement);
+
     if(viewingPreviousDraft){
         return;
     }

--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -24,6 +24,23 @@ let selectedChampion = null;
 let viewingPreviousDraft = false;
 let isLocking = false;
 
+//Dynamically fetching the CSS style for the hover and selection borders from draft.css
+//by instantiating a dummy div, assigning it a CSS style, then grabbing the border data as a 
+//string for use in colorBorder()
+const tempElement = document.createElement('div');
+document.body.appendChild(tempElement); // Append temporarily to get computed styles
+function fetchOutlineTempElement(className) { //Returns the CSS outline string from a CSS className in draft.css
+	tempElement.classList.value = ""; //clear all currently attached classes
+	tempElement.classList.add(className);
+	return getComputedStyle(tempElement).outline;
+}
+const headerSelectOutline = fetchOutlineTempElement('header-select-outline');
+const headerDefaultOutline = fetchOutlineTempElement('header-default-outline');
+const pickChampOutline = fetchOutlineTempElement('pick-champ-outline');
+// Remove the temp element after fetching the styles
+document.body.removeChild(tempElement);
+
+
 function startTimer() {
 	socket.emit('startTimer', draftId);
 }
@@ -264,7 +281,7 @@ function colorBorder() { //shows who is picking currently
     }
     // Reset the border for all side headers and slots
     document.querySelectorAll('.side-header').forEach(header => {
-        header.style.border = '2px solid black';
+        header.style.border = headerDefaultOutline;
     });
     document.querySelectorAll('.pick-slot, .ban-slot').forEach(slot => {
         slot.style.outline = 'none'; // Reset the border of all slots
@@ -272,21 +289,21 @@ function colorBorder() { //shows who is picking currently
 
     if(currPick == 0){ // color border based on side
         if (side === 'B') {
-            document.querySelector('#blue-side-header').style.border = '2px solid rgb(236, 209, 59)';
-            document.querySelector('#red-side-header').style.border = '2px solid black';
+            document.querySelector('#blue-side-header').style.border = headerSelectOutline;
+            document.querySelector('#red-side-header').style.border = headerDefaultOutline;
         } else if (side === 'R') {
-            document.querySelector('#red-side-header').style.border = '2px solid rgb(236, 209, 59)';
-            document.querySelector('#blue-side-header').style.border = '2px solid black';
+            document.querySelector('#red-side-header').style.border = headerSelectOutline;
+            document.querySelector('#blue-side-header').style.border = headerDefaultOutline;
         }
         return;
     }
     // Apply a golden border to the current side's header
     if (currSlot[0] === 'B') {
-        document.querySelector('#blue-side-header').style.border = '2px solid rgb(236, 209, 59)';
-        document.querySelector('#red-side-header').style.border = '2px solid black';
+        document.querySelector('#blue-side-header').style.border = headerSelectOutline;
+        document.querySelector('#red-side-header').style.border = headerDefaultOutline;
     } else {
-        document.querySelector('#red-side-header').style.border = '2px solid rgb(236, 209, 59)';
-        document.querySelector('#blue-side-header').style.border = '2px solid black';
+        document.querySelector('#red-side-header').style.border = headerSelectOutline;
+        document.querySelector('#blue-side-header').style.border = headerDefaultOutline;
     }
 
     // Highlight the current pick/ban slot
@@ -303,7 +320,7 @@ function colorBorder() { //shows who is picking currently
         }
     }
     if (pickOrBanSlot) {
-        pickOrBanSlot.style.outline = '2px solid rgb(236, 209, 59)'; // Golden outline for the current pick or ban slot
+        pickOrBanSlot.style.outline = pickChampOutline; // Golden outline for the current pick or ban slot
     }
 }
 


### PR DESCRIPTION
fixed the bug, since the fearless draft margins weren't being set by javascriopt code anymore the native CSS values took over, and the CSS default values had 60px and 54px margins for blue and red side respectively, just set the margins to 0px and -5px respectively and its fixed now. 
![image](https://github.com/user-attachments/assets/cac75dfe-fcee-41f6-94b7-4b4b3157605b)
![image](https://github.com/user-attachments/assets/56f0b060-78f5-4019-9e43-10151ac1b711)
